### PR TITLE
Classical potential builder

### DIFF
--- a/examples/csfq-example.py
+++ b/examples/csfq-example.py
@@ -134,22 +134,18 @@ plt.ylabel("$E_{g,0}$ (GHz)")
 # We see that beyond a certain inductance for the given parameters, the minimum gap closes to negligible value. To see why this happens we can analyse the potential of the system at half-flux:
 
 # +
-x = np.linspace(-0.5,0.5,201)
-Ej = Aj*Jc*hamil.getPrefactor('Ej')
-L1 = 500
-El = 0.5*hamil.getPrefactor('El')/L1
-V1 = -Ej*np.cos((x+0.5)*2*np.pi) + El*x**2
+hamil.setParameterValue("L", 500.0)
+potential, inputs = hamil.getClassicalPotentialFunction()
+V1 = potential({'phi1': x, 'phiZ': 0.0})
 
-L2 = 1000
-El = 0.5*hamil.getPrefactor('El')/L2
-V2 = -Ej*np.cos((x+0.5)*2*np.pi) + El*x**2
-# -
+hamil.setParameterValue("L", 1000.0)
+potential, inputs = hamil.getClassicalPotentialFunction()
+V2 = potential({'phi1': x, 'phiZ': 0.0})
 
-# Above we used the `getPrefactor` function to get the prefactors that ensure quantities are in consistent units. Here in GHz.
-
-plt.plot(x,V1,label="$L=%.1f$"%500)
-plt.plot(x,V2,label="$L=%.1f$"%1000)
+plt.plot(x, V1, label="$L=%.1f$"%500)
+plt.plot(x, V2, label="$L=%.1f$"%1000)
 plt.legend()
+# -
 
 # Indeed we see that when the inductance is large the Josephson energy influences the potential much more and forms a deeper double well, reducing the tunnel rate.
 
@@ -222,13 +218,19 @@ plt.ylabel("$E_{g,i}$ (GHz)")
 
 circuit.getClassicalHamiltonian()
 
-p1 = np.linspace(-1.0,1.0,201)
-p2 = np.linspace(-1.0,1.0,201)
-p1g,p2g = np.meshgrid(p1,p2)
+potential, inputs = hamil.getClassicalPotentialFunction()
+inputs
 
-Ej = Jc*Aj*hamil.getPrefactor('Ej')
-V1=-Ej*(np.cos(p1g*2*np.pi)+np.cos((p1g-p2g)*2*np.pi)+np.cos((p2g+0.5)*2*np.pi))
-V2=-Ej*(np.cos(p1g*2*np.pi)+np.cos((p1g-p2g)*2*np.pi)+np.cos((p2g+0.0)*2*np.pi))
+p1 = np.linspace(-1.0, 1.0, 201)
+p2 = np.linspace(-1.0, 1.0, 201)
+p1g, p2g = np.meshgrid(p1, p2)
+inputs['phi1'] = p1g
+inputs['phi2'] = p2g
+
+inputs['phiZ'] = 0.5
+V1 = potential(inputs)
+inputs['phiZ'] = 0.0
+V2 = potential(inputs)
 
 # +
 fig, ax = plt.subplots(ncols=2,nrows=1,constrained_layout=True,figsize=(13,5))
@@ -283,9 +285,14 @@ plt.ylabel("$E_{g,i}$ (GHz)")
 
 # Indeed we see that making one of the junctions smaller significantly increases the tunnel rate. We can compare the potential in this case:
 
-Ej = Jc*Aj*hamil.getPrefactor('Ej')
-Eja = alpha*Ej
-V1b=-Ej*(np.cos(p1g*2*np.pi) + np.cos((p2g+0.5)*2*np.pi)) - Eja*np.cos((p1g-p2g)*2*np.pi)
+potential, inputs = hamil.getClassicalPotentialFunction()
+inputs['phiZ'] = 0.5
+inputs['phi1'] = p1g
+inputs['phi2'] = p2g
+
+V1b = potential(inputs)
+
+V1b
 
 # +
 fig, ax = plt.subplots(ncols=2,nrows=1,constrained_layout=True,figsize=(13,5))

--- a/pyscqed/numerical_system.py
+++ b/pyscqed/numerical_system.py
@@ -803,6 +803,10 @@ class NumericalSystem(ds.TempData):
     ## Set the value of a parameter.
     def setParameterValue(self, name, value):
         self.SS.setParameterValue(name, value)
+        params = self.getParameterValuesDict()
+        assert all(value is not None for value in params.values()), \
+               "Some parameters do not have valid values. All parameters should be set first with the " \
+               "setParameterValues function in one go."
         self.substitute()
         self.prepareOperators()
     
@@ -813,6 +817,9 @@ class NumericalSystem(ds.TempData):
     ## Set many parameter values.
     def setParameterValues(self, *name_value_pairs):
         self.SS.setParameterValues(*name_value_pairs)
+        params = self.getParameterValuesDict()
+        assert all(value is not None for value in params.values()), "Not all parameters were set in this call. " \
+               f"The missing parameters are {repr([name for name, value in params.items() if value is None])}"
         self.substitute()
         self.prepareOperators()
     
@@ -911,7 +918,6 @@ class NumericalSystem(ds.TempData):
     ###################################################################################################################
     #       Internal Functions
     ###################################################################################################################
-
     def _evaluate_single(self, timesweep):
         results = []
         entry = self.evaluations[0]
@@ -1238,15 +1244,3 @@ class NumericalSystem(ds.TempData):
                     self.SS.addParameterisationPrefactor(resonator["gC"], self.units.getPrefactor('ChgOscCpl'))
                     self.SS.addParameterisationPrefactor(resonator["frl"], self.units.getPrefactor('Freq'))
                     self.SS.addParameterisationPrefactor(resonator["Zrl"], self.units.getPrefactor('Impe'))
-
-
-
-
-
-
-
-
-
-
-
-

--- a/pyscqed/numerical_system.py
+++ b/pyscqed/numerical_system.py
@@ -495,18 +495,18 @@ class NumericalSystem(ds.TempData):
     
     def getHamiltonian(self):
         # Get charging energy
-        self.Hq = self.units.getPrefactor("Ec")*0.5*\
+        Hq = self.units.getPrefactor("Ec")*0.5*\
         util.mdot((self.Qnp + self.Qbnp).T, self.Cinvnp, self.Qnp + self.Qbnp)[0, 0]
         
         # Get flux energy
-        self.Hf = self.units.getPrefactor("El")*0.5*\
+        Hf = self.units.getPrefactor("El")*0.5*\
         util.mdot((self.Pnp + self.Pbinp).T, self.Linvnp, self.Pnp + self.Pbinp)[0, 0]
         
         # Need the branch DoFs in the possibly transformed representation
         Pp = self.SS.Rnb*self.SS.Rinv*self.SS.node_vector
         
         # Get the Josephson energy
-        self.Hj = 0
+        Hj = 0
         for i, edge in enumerate(self.SS.edges):
             if self.Jvecnp[i] == 0.0:
                 continue
@@ -538,11 +538,11 @@ class NumericalSystem(ds.TempData):
                     prod1 *= self.circ_operators[node]["disp_adj"]
                     prod2 *= self.circ_operators[node]["disp"]
         
-            self.Hj += -0.5*self.Jvecnp[i]*(prod1 + prod2)
-        self.Hj *= self.units.getPrefactor("Ej")
+            Hj += -0.5*self.Jvecnp[i]*(prod1 + prod2)
+        Hj *= self.units.getPrefactor("Ej")
         
         # Get the Phaseslip energy
-        self.Hp = 0
+        Hp = 0
         for i, edge in enumerate(self.SS.edges):
             if self.Pvecnp[i] == 0.0:
                 continue
@@ -574,12 +574,11 @@ class NumericalSystem(ds.TempData):
                     prod1 *= self.circ_operators[node]["pdisp_adj"]
                     prod2 *= self.circ_operators[node]["pdisp"]
         
-            self.Hp += -0.5*self.Pvecnp[i]*(prod1 + prod2)
-        self.Hp *= self.units.getPrefactor("Ep")
+            Hp += -0.5*self.Pvecnp[i]*(prod1 + prod2)
+        Hp *= self.units.getPrefactor("Ep")
         
         # Total Hamiltonian
-        self.Ht = (self.Hq + self.Hf + self.Hj + self.Hp)
-        return self.Ht
+        return (Hq + Hf + Hj + Hp)
     
     def getCurrentOperator(self, edge=None):
         # Check edge


### PR DESCRIPTION
Introduces a builder for generating a numerical function for getting the classical potential energy (based on classical flux degrees of freedom) at any point.

Its most immediate use is for more easily and reliably visualising the classical potential for analysing a given system. However it has other more powerful internal uses, such as dynamically configuring the sparse diagonaliser during parameter sweeps.

Also some fixes:
1. Hamiltonian parts were saved as attributes, which was unnecessary and probably a remnant of some debugging in the past
2. Parameters that are not set at least once lead to a cryptic `sympy` error, so a more helpful error message is now generated